### PR TITLE
도메인을 Entity로 변환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,15 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/noose/todo/domain/schedule/Body.java
+++ b/src/main/java/com/noose/todo/domain/schedule/Body.java
@@ -1,10 +1,14 @@
 package com.noose.todo.domain.schedule;
 
+import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @EqualsAndHashCode
+@NoArgsConstructor
+@Embeddable
 public class Body {
 
     private static final int MAX_LENGTH = 500;

--- a/src/main/java/com/noose/todo/domain/schedule/Hashtag.java
+++ b/src/main/java/com/noose/todo/domain/schedule/Hashtag.java
@@ -1,11 +1,26 @@
 package com.noose.todo.domain.schedule;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class Hashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "hashtag_id")
+    private Long id;
 
     @Getter
     private String hashtagName;
+
+    @OneToMany(mappedBy = "hashtag")
+    private List<NoteHashtag> noteHashtags;
 
     public Hashtag(String hashtagName) {
         if (hashtagName == null) {

--- a/src/main/java/com/noose/todo/domain/schedule/Hashtags.java
+++ b/src/main/java/com/noose/todo/domain/schedule/Hashtags.java
@@ -1,5 +1,6 @@
 package com.noose.todo.domain.schedule;
 
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,10 +14,12 @@ import java.util.stream.Collectors;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@Embeddable
 public class Hashtags {
     private static final Pattern HASHTAG_PATTERN = Pattern.compile("#[\\w가-힣]+");
 
     @Getter
+    @OneToMany(mappedBy = "hashtag")
     private Set<Hashtag> values = new LinkedHashSet<>();
 
     public Hashtags(Body body) {

--- a/src/main/java/com/noose/todo/domain/schedule/NoteHashtag.java
+++ b/src/main/java/com/noose/todo/domain/schedule/NoteHashtag.java
@@ -1,0 +1,23 @@
+package com.noose.todo.domain.schedule;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class NoteHashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "note_hashtag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_note_id")
+    private ScheduleNote scheduleNote;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag;
+}

--- a/src/main/java/com/noose/todo/domain/schedule/Period.java
+++ b/src/main/java/com/noose/todo/domain/schedule/Period.java
@@ -1,5 +1,6 @@
 package com.noose.todo.domain.schedule;
 
+import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -7,6 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @EqualsAndHashCode
+@Embeddable
 public class Period {
 
     private LocalDateTime startDate;

--- a/src/main/java/com/noose/todo/domain/schedule/ScheduleNote.java
+++ b/src/main/java/com/noose/todo/domain/schedule/ScheduleNote.java
@@ -1,18 +1,32 @@
 package com.noose.todo.domain.schedule;
 
-import lombok.AllArgsConstructor;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Entity
 public class ScheduleNote {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "schedule_note_id")
+    private Long id;
+    @Embedded
     private Title title;
+    @Embedded
     private Body body;
-
-    private Hashtags hashtags;
-    private Todos todos;
+    @Embedded
     private Period period;
+    @OneToMany(mappedBy = "scheduleNote")
+    private List<NoteHashtag> noteHashtags = new ArrayList<>();
+    @Embedded
+    private Todos todos;
 
     public static ScheduleNote of(String title) {
         return of(title, "");
@@ -20,7 +34,15 @@ public class ScheduleNote {
 
     public static ScheduleNote of(String title, String body) {
         Body newBody = new Body(body);
-        return new ScheduleNote(new Title(title), newBody, new Hashtags(newBody), new Todos(), new Period());
+        return new ScheduleNote(null, new Title(title), new Body(body), new Period(), new Todos());
+    }
+
+    private ScheduleNote(Long id, Title title, Body body, Period period, Todos todos) {
+        this.id = id;
+        this.title = title;
+        this.body = body;
+        this.period = period;
+        this.todos = todos;
     }
 
     public boolean isEmptyBody() {

--- a/src/main/java/com/noose/todo/domain/schedule/Title.java
+++ b/src/main/java/com/noose/todo/domain/schedule/Title.java
@@ -1,14 +1,20 @@
 package com.noose.todo.domain.schedule;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 @EqualsAndHashCode
+@Embeddable
 public class Title {
 
     private static final int MAX_LENGTH = 20;
 
+    @Column(name = "title")
     private String value;
 
     public Title(String value) {

--- a/src/main/java/com/noose/todo/domain/schedule/Todo.java
+++ b/src/main/java/com/noose/todo/domain/schedule/Todo.java
@@ -1,11 +1,25 @@
 package com.noose.todo.domain.schedule;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class Todo {
 
     private static final int MAX_LENGTH = 30;
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "todo_id")
+    private Long id;
     private String contents;
     private Status status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_note_id")
+    private ScheduleNote scheduleNote;
 
     public Todo(String contents) {
         if (contents == null || contents.isEmpty()) {

--- a/src/main/java/com/noose/todo/domain/schedule/Todos.java
+++ b/src/main/java/com/noose/todo/domain/schedule/Todos.java
@@ -1,9 +1,14 @@
 package com.noose.todo.domain.schedule;
 
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+
 import java.util.ArrayList;
 import java.util.List;
 
+@Embeddable
 public class Todos {
+    @OneToMany(mappedBy = "scheduleNote")
     private List<Todo> todos = new ArrayList<>();
 
     public Todos() {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,1 +1,6 @@
-
+spring:
+  h2:
+    console:
+      enabled: true
+  datasource:
+    url: jdbc:h2:mem:testdb

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,3 +4,7 @@ spring:
       enabled: true
   datasource:
     url: jdbc:h2:mem:testdb
+
+  jpa:
+    hibernate:
+      ddl-auto: create


### PR DESCRIPTION
JPA

- 도메인을 Entity로 변환 및 연관관계 매핑
- DB는 아직 미정이라 H2 DB를 사용

close #8 